### PR TITLE
ADD Etag support

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,26 @@ post_object["name"]
 # => "namevine"
 ```
 
+
+## Etag
+
+You can retrieve last request etag using `ProductHunt::Client#etag` :
+
+```ruby
+client = ProductHunt::Client.new('mytoken')
+post = client.post(3372)
+etag = client.last_etag
+```
+
+You then can leverage [its API support](https://api.producthunt.com/v1/docs/example_performance_tips/use_the_e-tag_http_header) to increase performances by passing it as custom header:
+
+```ruby
+post = client.post(3372, headers: { 'If-None-Match': etag })
+```
+
+This will ensure you get only newest records. If there is no new record, API methods will return nil.
+
+
 ## Tests
 
 There are two ways to run tests:

--- a/lib/product_hunt/api/posts.rb
+++ b/lib/product_hunt/api/posts.rb
@@ -5,20 +5,23 @@ module ProductHunt
       PATH = "/posts"
 
       def posts(options = {})
-        fetch(PATH, options)["posts"].map{ |post| Post.new(post, self) }
+        response = fetch(PATH, options)
+        response["posts"].map{ |post| Post.new(post, self) } if response.code == 200
       end
 
       def post(id, options = {})
-        post = fetch(PATH + "/#{id}", options)["post"]
-        Post.new(post, self)
+        post = fetch(PATH + "/#{id}", options)
+        Post.new(post["post"], self) if post.code == 200
       end
 
       def comments_for_post(id, options = {})
-        fetch(PATH + "/#{id}/comments", options)["comments"].map{ |c| Comment.new(c, self) }
+        response = fetch(PATH + "/#{id}/comments", options)
+        response["comments"].map{ |c| Comment.new(c, self) } if response.code == 200
       end
 
       def votes_for_post(id, options = {})
-        fetch(PATH + "/#{id}/votes", options)["votes"].map{ |c| Vote.new(c, self) }
+        response = fetch(PATH + "/#{id}/votes", options)
+        response["votes"].map{ |c| Vote.new(c, self) } if response.code == 200
       end
     end
   end

--- a/lib/product_hunt/api/users.rb
+++ b/lib/product_hunt/api/users.rb
@@ -5,8 +5,8 @@ module ProductHunt
       PATH = "/users"
 
       def user(id, options = {})
-        user = fetch(PATH + "/#{id}", options)["user"]
-        User.new(user, self)
+        user = fetch(PATH + "/#{id}", options)
+        User.new(user["user"], self) if user.code == 200
       end
 
     end

--- a/lib/product_hunt/client.rb
+++ b/lib/product_hunt/client.rb
@@ -6,6 +6,7 @@ module ProductHunt
     include HTTParty
     base_uri 'https://api.producthunt.com/v1/'
     format :json
+    attr_reader :config, :last_etag
 
     include ProductHunt::API
 
@@ -13,16 +14,18 @@ module ProductHunt
       @config = { headers: { "Authorization" => "Bearer #{token}" } }
     end
 
-    def config
-      @config
-    end
-
     def fetch(path, params)
+      headers = params.has_key?(:headers) ? params.delete(:headers) : {}
       queryopts = if params.is_a?(Enumerable) && params.size > 0
         "?" + URI.encode_www_form(params)
       end
 
-      self.class.get(path + (queryopts || ""), @config)
+      request_config = config.dup
+      request_config[ :headers ] = request_config[ :headers ].merge(headers)
+
+      response = self.class.get(path + (queryopts || ""), request_config)
+      @last_etag = response.headers['etag']
+      response
     end
   end
 end

--- a/spec/support/index_response.txt
+++ b/spec/support/index_response.txt
@@ -1,5 +1,6 @@
 HTTP/1.1 200 OK
 Content-Type: application/json; charset=utf-8
+ETag: "b45b3ee1d10ba50fae6bbc6d9fb79a88"
 
 {
     "posts": [


### PR DESCRIPTION
In order to take advantage of product hunt's API Etag support, allows to
retrieve etag and to set custom headers for requests.

``` ruby
client = ProductHunt::Client.new('mytoken')
post = client.post(3372)
etag = client.last_etag # retrieve etag from last request

post = client.post(3372, headers: { 'If-None-Match': etag }) # only newer records
```

If there is no new record (response will return a 304 status), API
methods will just return nil.
